### PR TITLE
Implements demo auth buttons

### DIFF
--- a/client/src/components/DemoLogin/DemoLogin.tsx
+++ b/client/src/components/DemoLogin/DemoLogin.tsx
@@ -3,14 +3,7 @@ import Box from '@mui/material/Box';
 import login from '../../helpers/APICalls/login';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  submit: {
-    height: 56,
-  },
-}));
+import { useStyles } from './useStyles';
 
 export default function DemoLogin(): JSX.Element {
   const classes = useStyles();

--- a/client/src/components/DemoLogin/DemoLogin.tsx
+++ b/client/src/components/DemoLogin/DemoLogin.tsx
@@ -8,7 +8,6 @@ import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   submit: {
-    padding: theme.spacing(2),
     height: 56,
   },
 }));

--- a/client/src/components/DemoLogin/DemoLogin.tsx
+++ b/client/src/components/DemoLogin/DemoLogin.tsx
@@ -1,0 +1,79 @@
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import login from '../../helpers/APICalls/login';
+import { useAuth } from '../../context/useAuthContext';
+import { useSnackBar } from '../../context/useSnackbarContext';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  submit: {
+    padding: theme.spacing(2),
+    height: 56,
+  },
+}));
+
+export default function DemoLogin(): JSX.Element {
+  const classes = useStyles();
+  const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+
+  const dogOwner = {
+    email: 'dogowner@demo.com',
+    password: 'Test123!',
+  };
+
+  const dogSitter = {
+    email: 'dogsitter@demo.com',
+    password: 'Test123!',
+  };
+
+  const signIn = ({ email, password }: { email: string; password: string }) => {
+    login(email, password).then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateLoginContext(data.success);
+      } else {
+        console.error({ data });
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  };
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        textAlign: 'center',
+        marginTop: 4,
+        paddingTop: 2.5,
+        fontSize: 20,
+        display: 'flex',
+        justifyContent: 'space-between',
+        borderTop: 'solid 1px gray',
+      }}
+    >
+      <Button
+        className={classes.submit}
+        onClick={() => signIn(dogOwner)}
+        size="large"
+        variant="contained"
+        color="primary"
+        disableElevation
+      >
+        Demo Dog Owner
+      </Button>
+      <Button
+        className={classes.submit}
+        onClick={() => signIn(dogSitter)}
+        size="large"
+        variant="contained"
+        color="primary"
+        disableElevation
+      >
+        Demo Dog Sitter
+      </Button>
+    </Box>
+  );
+}

--- a/client/src/components/DemoLogin/useStyles.ts
+++ b/client/src/components/DemoLogin/useStyles.ts
@@ -1,0 +1,15 @@
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+
+export const useStyles = makeStyles((theme: Theme) => ({
+  submit: {
+    margin: theme.spacing(3, 2, 2),
+    padding: 10,
+    width: 160,
+    height: 56,
+    borderRadius: theme.shape.borderRadius,
+    marginTop: 49,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+}));

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -3,6 +3,7 @@ import login from '../../helpers/APICalls/login';
 import LoginForm from './LoginForm/LoginForm';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import DemoLogin from '../../components/DemoLogin/DemoLogin';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
@@ -35,6 +36,7 @@ export default function Login(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Log in">
         <LoginForm handleSubmit={handleSubmit} />
+        <DemoLogin />
         <AuthPageFooter text="Not a member?" anchorText="Sign up" anchorTo="/signup" />
       </AuthPageWrapper>
     </PageContainer>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -3,6 +3,7 @@ import register from '../../helpers/APICalls/register';
 import SignUpForm from './SignUpForm/SignUpForm';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import DemoLogin from '../../components/DemoLogin/DemoLogin';
 import AuthPageWrapper from '../../components/AuthPageWrapper/AuthPageWrapper';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AuthPageFooter from '../../components/AuthPageFooter/AuthPageFooter';
@@ -36,6 +37,7 @@ export default function Register(): JSX.Element {
     <PageContainer>
       <AuthPageWrapper header="Sign up">
         <SignUpForm handleSubmit={handleSubmit} />
+        <DemoLogin />
         <AuthPageFooter text="Already a member?" anchorText="Login" anchorTo="/login" />
       </AuthPageWrapper>
     </PageContainer>


### PR DESCRIPTION
resolves #45 - FE: Demo User

### What this PR does (required):
- Allow recruiters and managers to easily test the app's features without having to sign up by clicking hard-coded credential buttons.

### Screenshots / Videos (front-end only):
- Login Page
<img width="961" alt="login_page (2)" src="https://user-images.githubusercontent.com/18078583/151447108-5be7680c-5bd5-4dff-a0ab-7a9b39e62a59.png">

- Sign Up Page
<img width="961" alt="signup_page (2)" src="https://user-images.githubusercontent.com/18078583/151447137-b67ea652-db08-424a-a5de-ecd58b44141b.png">

- After clicking 'Demo Dog Owner' or 'Demo Dog Sitter'. The expected result should be the dashboard page.
<img width="1262" alt="dashboard_page" src="https://user-images.githubusercontent.com/18078583/151321975-5d0a6552-1bb8-4622-8012-5434e4c0f9b7.png">


### Any information needed to test this feature (required):
- Manually register these users, only for the first time.
  - Dog Owner
    - Username: Dog Owner
    - Email: dogowner@demo.com
    - Password: Test123!
  - Dog Sitter
    - Username: Dog Sitter
    - Email: dogsitter@demo.com
    - Password: Test123!
    
Walkthrough
1. Logout from any session, then visit the Login Page and click the 'Demo Dog Owner' button
2. Expect to get redirected to the dashboard page as a Dog Owner user
3. Logout from any session, then visit the Sign Up Page and click the 'Demo Dog Sitter' button
4. Expect to get redirected to the dashboard page as a Dog Sitter user
